### PR TITLE
Add Sign in with Apple auth support in iOS app

### DIFF
--- a/frontend/The Punch/Views/Screens/Auth/CreateAccountView.swift
+++ b/frontend/The Punch/Views/Screens/Auth/CreateAccountView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FirebaseAuth
+import AuthenticationServices
 
 /**
 The view that allows users to create accounts.
@@ -17,6 +18,7 @@ struct CreateAccountView: View {
     // Connect to AuthManager to handle authentication
     @StateObject private var authManager = AuthManager.shared
     @StateObject private var googleSignIn = GoogleSignInHandler()
+    @StateObject private var appleSignIn = AppleSignInHandler()
 
     @State private var username = ""
     @State private var email = ""
@@ -28,6 +30,7 @@ struct CreateAccountView: View {
 
     @State private var isLoading = false
     @State private var isGoogleLoading = false
+    @State private var isAppleLoading = false
     @State private var errorMessage = ""
     @State private var showError = false
     @State private var infoMessage = ""
@@ -143,7 +146,7 @@ struct CreateAccountView: View {
                         .padding(.horizontal, 50)
 
                         // Sign up with Google
-                        if isGoogleLoading {
+                        if isGoogleLoading || isAppleLoading {
                             ProgressView()
                                 .progressViewStyle(CircularProgressViewStyle(tint: .white))
                                 .scaleEffect(1.5)
@@ -173,6 +176,25 @@ struct CreateAccountView: View {
                                 .background(Color.white)
                                 .cornerRadius(25)
                             }
+                            .padding(.horizontal, 50)
+
+                            SignInWithAppleButton(.signUp) { request in
+                                appleSignIn.prepare(request: request)
+                            } onCompletion: { result in
+                                Task {
+                                    isAppleLoading = true
+                                    defer { isAppleLoading = false }
+                                    do {
+                                        try await appleSignIn.handle(result: result)
+                                    } catch {
+                                        errorMessage = error.localizedDescription
+                                        showError = true
+                                    }
+                                }
+                            }
+                            .signInWithAppleButtonStyle(.white)
+                            .frame(height: 50)
+                            .cornerRadius(25)
                             .padding(.horizontal, 50)
                         }
 

--- a/frontend/The Punch/Views/Screens/Auth/GoogleSignInHandler.swift
+++ b/frontend/The Punch/Views/Screens/Auth/GoogleSignInHandler.swift
@@ -8,6 +8,10 @@
 import Foundation
 import GoogleSignIn
 import FirebaseAuth
+import AuthenticationServices
+import CryptoKit
+import UIKit
+import Security
 
 @MainActor
 final class GoogleSignInHandler: ObservableObject {
@@ -51,6 +55,82 @@ final class GoogleSignInHandler: ObservableObject {
     }
 }
 
+@MainActor
+final class AppleSignInHandler: ObservableObject {
+    private var currentNonce: String?
+
+    func prepare(request: ASAuthorizationAppleIDRequest) {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+    }
+
+    func handle(result: Result<ASAuthorization, Error>) async throws {
+        switch result {
+        case .failure(let error):
+            throw error
+
+        case .success(let authorization):
+            guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+                throw AppleSignInError.invalidCredential
+            }
+
+            guard let nonce = currentNonce else {
+                throw AppleSignInError.invalidState
+            }
+
+            guard let appleIDToken = appleIDCredential.identityToken,
+                  let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                throw AppleSignInError.missingToken
+            }
+
+            let credential = OAuthProvider.credential(
+                providerID: "apple.com",
+                idToken: idTokenString,
+                rawNonce: nonce
+            )
+
+            try await Auth.auth().signIn(with: credential)
+            try await AuthManager.shared.syncSessionWithBackend()
+        }
+    }
+
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            var randoms: [UInt8] = Array(repeating: 0, count: 16)
+            let errorCode = SecRandomCopyBytes(kSecRandomDefault, randoms.count, &randoms)
+            if errorCode != errSecSuccess {
+                fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+}
+
 enum GoogleSignInError: LocalizedError {
     case noRootViewController
     case missingToken
@@ -59,6 +139,23 @@ enum GoogleSignInError: LocalizedError {
         switch self {
         case .noRootViewController: return "Unable to present sign-in screen."
         case .missingToken:         return "Google sign-in failed. Please try again."
+        }
+    }
+}
+
+enum AppleSignInError: LocalizedError {
+    case invalidCredential
+    case invalidState
+    case missingToken
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCredential:
+            return "Apple sign-in failed. Please try again."
+        case .invalidState:
+            return "Apple sign-in request expired. Please try again."
+        case .missingToken:
+            return "Missing Apple identity token. Please try again."
         }
     }
 }

--- a/frontend/The Punch/Views/Screens/Auth/LoginView.swift
+++ b/frontend/The Punch/Views/Screens/Auth/LoginView.swift
@@ -7,16 +7,19 @@
 
 import SwiftUI
 import FirebaseAuth
+import AuthenticationServices
 
 struct LoginView: View {
     // Single source of truth for auth state
     @StateObject private var authManager = AuthManager.shared
     @StateObject private var googleSignIn = GoogleSignInHandler()
+    @StateObject private var appleSignIn = AppleSignInHandler()
 
     @State private var email = ""
     @State private var password = ""
     @State private var isLoading = false
     @State private var isGoogleLoading = false
+    @State private var isAppleLoading = false
     @State private var errorMessage = ""
     @State private var showError = false
     @State private var infoMessage = ""
@@ -66,7 +69,7 @@ struct LoginView: View {
                     }
                     .foregroundColor(.white.opacity(0.85))
                     .font(.footnote)
-                    .disabled(isLoading || isGoogleLoading)
+                    .disabled(isLoading || isGoogleLoading || isAppleLoading)
 
                     // Log In button
                     if isLoading {
@@ -91,7 +94,7 @@ struct LoginView: View {
                     .padding(.horizontal, 50)
 
                     // Sign in with Google
-                    if isGoogleLoading {
+                    if isGoogleLoading || isAppleLoading {
                         ProgressView()
                             .progressViewStyle(CircularProgressViewStyle(tint: .white))
                             .scaleEffect(1.5)
@@ -121,6 +124,25 @@ struct LoginView: View {
                             .background(Color.white)
                             .cornerRadius(25)
                         }
+                        .padding(.horizontal, 50)
+
+                        SignInWithAppleButton(.signIn) { request in
+                            appleSignIn.prepare(request: request)
+                        } onCompletion: { result in
+                            Task {
+                                isAppleLoading = true
+                                defer { isAppleLoading = false }
+                                do {
+                                    try await appleSignIn.handle(result: result)
+                                } catch {
+                                    errorMessage = error.localizedDescription
+                                    showError = true
+                                }
+                            }
+                        }
+                        .signInWithAppleButtonStyle(.white)
+                        .frame(height: 50)
+                        .cornerRadius(25)
                         .padding(.horizontal, 50)
                     }
 


### PR DESCRIPTION
### Motivation
- Add Apple Sign-In so users can authenticate via Apple and have that identity bridged into Firebase and the existing backend session flow.
- Reuse the same backend-provisioning path that already accepts Firebase ID tokens so provider-specific work is minimized.

### Description
- Added an `AppleSignInHandler` that generates a Firebase-compatible nonce, hashes it with SHA256, exchanges the Apple identity token for a Firebase `OAuthProvider` credential, signs into Firebase, and calls `AuthManager.shared.syncSessionWithBackend()` (`frontend/The Punch/Views/Screens/Auth/GoogleSignInHandler.swift`).
- Added `SignInWithAppleButton` to the `LoginView` and `CreateAccountView` with coordinated loading state and error handling so Apple and Google flows don’t overlap (`frontend/The Punch/Views/Screens/Auth/LoginView.swift`, `frontend/The Punch/Views/Screens/Auth/CreateAccountView.swift`).
- Added necessary imports (`AuthenticationServices`, `CryptoKit`, `Security`, etc.) and small UI changes (new `@StateObject appleSignIn` and `isAppleLoading` state variables) to support the flow.
- No backend code or DB schema changes were required because the server verifies Firebase ID tokens provider-agnostically; the controller already provisions users from `decoded.uid`/`decoded.email` when needed (`backend/src/controllers/authController.js`, `backend/src/models/User.js`).

### Testing
- Attempted to run `xcodebuild -list -project frontend/ThePunch.xcodeproj`, but the command failed in this environment because `xcodebuild` is not installed (so iOS build/test could not be executed here).
- Verified repository changes locally by committing the modifications (`git commit` succeeded with message: "Add Sign in with Apple auth flow").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d934024790832f964a70220c15c598)