### PR TITLE
Add Sign in with Apple, make phone number optional, and enable phone editing UI

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -72,19 +72,14 @@ const completeProfile = async (req, res) => {
       });
     }
 
-    if (!phone_number || !String(phone_number).trim()) {
-      return res.status(400).json({
-        success: false,
-        message: 'phone_number is required'
-      });
-    }
-
-    const existingPhoneUser = await User.findByPhoneNumber(phone_number);
-    if (existingPhoneUser && existingPhoneUser.firebase_uid !== decoded.uid) {
-      return res.status(409).json({
-        success: false,
-        message: 'User with this phone number already exists'
-      });
+    if (phone_number && String(phone_number).trim()) {
+      const existingPhoneUser = await User.findByPhoneNumber(phone_number);
+      if (existingPhoneUser && existingPhoneUser.firebase_uid !== decoded.uid) {
+        return res.status(409).json({
+          success: false,
+          message: 'User with this phone number already exists'
+        });
+      }
     }
 
     let user = await User.findByFirebaseUid(decoded.uid);

--- a/frontend/The Punch/Services/APIService.swift
+++ b/frontend/The Punch/Services/APIService.swift
@@ -839,7 +839,9 @@ extension APIService {
             ])
         }
 
-        let decoded = try JSONDecoder().decode(UserResponse.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let decoded = try decoder.decode(UserResponse.self, from: data)
         return decoded.data
     }
 }

--- a/frontend/The Punch/Views/Screens/Auth/CreateAccountView.swift
+++ b/frontend/The Punch/Views/Screens/Auth/CreateAccountView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FirebaseAuth
+import AuthenticationServices
 
 /**
 The view that allows users to create accounts.
@@ -17,6 +18,7 @@ struct CreateAccountView: View {
     // Connect to AuthManager to handle authentication
     @StateObject private var authManager = AuthManager.shared
     @StateObject private var googleSignIn = GoogleSignInHandler()
+    @StateObject private var appleSignIn = AppleSignInHandler()
 
     @State private var username = ""
     @State private var email = ""
@@ -28,6 +30,7 @@ struct CreateAccountView: View {
 
     @State private var isLoading = false
     @State private var isGoogleLoading = false
+    @State private var isAppleLoading = false
     @State private var errorMessage = ""
     @State private var showError = false
     @State private var infoMessage = ""
@@ -71,7 +74,7 @@ struct CreateAccountView: View {
                                 .autocapitalization(.none)
                                 .keyboardType(.emailAddress)
                             RoundedSecureField(placeholder: "Password", text: $password)
-                            RoundedTextField(placeholder: "Phone Number", text: $phoneNumber)
+                            RoundedTextField(placeholder: "Phone Number (optional)", text: $phoneNumber)
                                 .keyboardType(.phonePad)
                             
                             Toggle("Allow friend suggestions by phone number", isOn: $discoverableByPhone)
@@ -124,9 +127,7 @@ struct CreateAccountView: View {
                                 if email.isEmpty { validationText("Email required") }
                                 if password.isEmpty { validationText("Password required") }
                                 else if password.count < 6 { validationText("Password must be at least 6 characters") }
-                                if phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                                    validationText("Phone number required")
-                                } else if !isValidPhoneNumber(phoneNumber) {
+                                if !phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isValidPhoneNumber(phoneNumber) {
                                     validationText("Enter a valid US phone number")
                                 }
                                 if !acceptedTerms { validationText("Must accept terms & conditions") }
@@ -143,7 +144,7 @@ struct CreateAccountView: View {
                         .padding(.horizontal, 50)
 
                         // Sign up with Google
-                        if isGoogleLoading {
+                        if isGoogleLoading || isAppleLoading {
                             ProgressView()
                                 .progressViewStyle(CircularProgressViewStyle(tint: .white))
                                 .scaleEffect(1.5)
@@ -173,6 +174,25 @@ struct CreateAccountView: View {
                                 .background(Color.white)
                                 .cornerRadius(25)
                             }
+                            .padding(.horizontal, 50)
+
+                            SignInWithAppleButton(.signUp) { request in
+                                appleSignIn.prepare(request: request)
+                            } onCompletion: { result in
+                                Task {
+                                    isAppleLoading = true
+                                    defer { isAppleLoading = false }
+                                    do {
+                                        try await appleSignIn.handle(result: result)
+                                    } catch {
+                                        errorMessage = error.localizedDescription
+                                        showError = true
+                                    }
+                                }
+                            }
+                            .signInWithAppleButtonStyle(.white)
+                            .frame(height: 50)
+                            .cornerRadius(25)
                             .padding(.horizontal, 50)
                         }
 
@@ -228,10 +248,15 @@ struct CreateAccountView: View {
         !email.isEmpty &&
         isValidEmail(email) &&
         password.count >= 6 &&
-        isValidPhoneNumber(phoneNumber) &&
+        isPhoneNumberValidOrEmpty &&
         acceptedTerms
     }
     
+    var isPhoneNumberValidOrEmpty: Bool {
+        let trimmed = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty || isValidPhoneNumber(trimmed)
+    }
+
     /**
      Validate email format.
      Uses regex to check if email looks valid.

--- a/frontend/The Punch/Views/Screens/Auth/GoogleSignInHandler.swift
+++ b/frontend/The Punch/Views/Screens/Auth/GoogleSignInHandler.swift
@@ -8,6 +8,10 @@
 import Foundation
 import GoogleSignIn
 import FirebaseAuth
+import AuthenticationServices
+import CryptoKit
+import UIKit
+import Security
 
 @MainActor
 final class GoogleSignInHandler: ObservableObject {
@@ -51,6 +55,82 @@ final class GoogleSignInHandler: ObservableObject {
     }
 }
 
+@MainActor
+final class AppleSignInHandler: ObservableObject {
+    private var currentNonce: String?
+
+    func prepare(request: ASAuthorizationAppleIDRequest) {
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+    }
+
+    func handle(result: Result<ASAuthorization, Error>) async throws {
+        switch result {
+        case .failure(let error):
+            throw error
+
+        case .success(let authorization):
+            guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+                throw AppleSignInError.invalidCredential
+            }
+
+            guard let nonce = currentNonce else {
+                throw AppleSignInError.invalidState
+            }
+
+            guard let appleIDToken = appleIDCredential.identityToken,
+                  let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                throw AppleSignInError.missingToken
+            }
+
+            let credential = OAuthProvider.credential(
+                providerID: .apple,
+                idToken: idTokenString,
+                rawNonce: nonce
+            )
+
+            try await Auth.auth().signIn(with: credential)
+            try await AuthManager.shared.syncSessionWithBackend()
+        }
+    }
+
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            var randoms: [UInt8] = Array(repeating: 0, count: 16)
+            let errorCode = SecRandomCopyBytes(kSecRandomDefault, randoms.count, &randoms)
+            if errorCode != errSecSuccess {
+                fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+}
+
 enum GoogleSignInError: LocalizedError {
     case noRootViewController
     case missingToken
@@ -59,6 +139,23 @@ enum GoogleSignInError: LocalizedError {
         switch self {
         case .noRootViewController: return "Unable to present sign-in screen."
         case .missingToken:         return "Google sign-in failed. Please try again."
+        }
+    }
+}
+
+enum AppleSignInError: LocalizedError {
+    case invalidCredential
+    case invalidState
+    case missingToken
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCredential:
+            return "Apple sign-in failed. Please try again."
+        case .invalidState:
+            return "Apple sign-in request expired. Please try again."
+        case .missingToken:
+            return "Missing Apple identity token. Please try again."
         }
     }
 }

--- a/frontend/The Punch/Views/Screens/Auth/LoginView.swift
+++ b/frontend/The Punch/Views/Screens/Auth/LoginView.swift
@@ -7,16 +7,19 @@
 
 import SwiftUI
 import FirebaseAuth
+import AuthenticationServices
 
 struct LoginView: View {
     // Single source of truth for auth state
     @StateObject private var authManager = AuthManager.shared
     @StateObject private var googleSignIn = GoogleSignInHandler()
+    @StateObject private var appleSignIn = AppleSignInHandler()
 
     @State private var email = ""
     @State private var password = ""
     @State private var isLoading = false
     @State private var isGoogleLoading = false
+    @State private var isAppleLoading = false
     @State private var errorMessage = ""
     @State private var showError = false
     @State private var infoMessage = ""
@@ -66,7 +69,7 @@ struct LoginView: View {
                     }
                     .foregroundColor(.white.opacity(0.85))
                     .font(.footnote)
-                    .disabled(isLoading || isGoogleLoading)
+                    .disabled(isLoading || isGoogleLoading || isAppleLoading)
 
                     // Log In button
                     if isLoading {
@@ -91,7 +94,7 @@ struct LoginView: View {
                     .padding(.horizontal, 50)
 
                     // Sign in with Google
-                    if isGoogleLoading {
+                    if isGoogleLoading || isAppleLoading {
                         ProgressView()
                             .progressViewStyle(CircularProgressViewStyle(tint: .white))
                             .scaleEffect(1.5)
@@ -121,6 +124,25 @@ struct LoginView: View {
                             .background(Color.white)
                             .cornerRadius(25)
                         }
+                        .padding(.horizontal, 50)
+
+                        SignInWithAppleButton(.signIn) { request in
+                            appleSignIn.prepare(request: request)
+                        } onCompletion: { result in
+                            Task {
+                                isAppleLoading = true
+                                defer { isAppleLoading = false }
+                                do {
+                                    try await appleSignIn.handle(result: result)
+                                } catch {
+                                    errorMessage = error.localizedDescription
+                                    showError = true
+                                }
+                            }
+                        }
+                        .signInWithAppleButtonStyle(.white)
+                        .frame(height: 50)
+                        .cornerRadius(25)
                         .padding(.horizontal, 50)
                     }
 

--- a/frontend/The Punch/Views/Screens/Auth/UsernameSetupView.swift
+++ b/frontend/The Punch/Views/Screens/Auth/UsernameSetupView.swift
@@ -15,6 +15,8 @@ struct UsernameSetupView: View {
 
     @State private var username = ""
     @State private var displayName = ""
+    @State private var phoneNumber = ""
+    @State private var discoverableByPhone = true
     @State private var acceptedTerms = false
     @State private var isLoading = false
     @State private var errorMessage = ""
@@ -47,6 +49,13 @@ struct UsernameSetupView: View {
                         .autocapitalization(.none)
 
                     RoundedTextField(placeholder: "Display Name (optional)", text: $displayName)
+
+                    RoundedTextField(placeholder: "Phone Number", text: $phoneNumber)
+                        .keyboardType(.phonePad)
+
+                    Toggle("Allow friend suggestions by phone number", isOn: $discoverableByPhone)
+                        .toggleStyle(SwitchToggleStyle(tint: .orange))
+                        .foregroundColor(.white.opacity(0.9))
                 }
                 .padding(.horizontal, 40)
                 .padding(.top, 10)
@@ -77,6 +86,9 @@ struct UsernameSetupView: View {
                     VStack(spacing: 4) {
                         if username.count < 3 {
                             validationText("Username must be at least 3 characters")
+                        }
+                        if !phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isValidPhoneNumber(phoneNumber) {
+                            validationText("Enter a valid US phone number")
                         }
                         if !acceptedTerms {
                             validationText("Must accept terms & conditions")
@@ -114,7 +126,17 @@ struct UsernameSetupView: View {
     }
 
     var isFormValid: Bool {
-        username.count >= 3 && acceptedTerms
+        username.count >= 3 && isPhoneNumberValidOrEmpty && acceptedTerms
+    }
+
+    var isPhoneNumberValidOrEmpty: Bool {
+        let trimmed = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty || isValidPhoneNumber(trimmed)
+    }
+
+    func isValidPhoneNumber(_ phoneNumber: String) -> Bool {
+        let digits = phoneNumber.filter(\.isNumber)
+        return digits.count == 10 || (digits.count == 11 && digits.first == "1")
     }
 
     func validationText(_ text: String) -> some View {
@@ -136,8 +158,8 @@ struct UsernameSetupView: View {
                 firebaseToken: token,
                 username: username.trimmingCharacters(in: .whitespaces),
                 displayName: displayName.isEmpty ? username : displayName,
-                phoneNumber: nil,
-                discoverableByPhone: true
+                phoneNumber: phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines),
+                discoverableByPhone: discoverableByPhone
             )
             try await AuthManager.shared.syncSessionWithBackend()
         } catch {

--- a/frontend/The Punch/Views/Screens/Utility/AccountInformationView.swift
+++ b/frontend/The Punch/Views/Screens/Utility/AccountInformationView.swift
@@ -5,12 +5,24 @@
 //  Created by Valerie Williams on 4/1/26.
 //
 
-
 import SwiftUI
 
 struct AccountInformationView: View {
+    @EnvironmentObject private var authManager: AuthManager
+
     let user: User
     var onUserUpdated: ((User) -> Void)? = nil
+
+    @State private var phoneNumber: String
+    @State private var isSaving = false
+    @State private var showSaved = false
+    @State private var errorMessage: String?
+
+    init(user: User, onUserUpdated: ((User) -> Void)? = nil) {
+        self.user = user
+        self.onUserUpdated = onUserUpdated
+        _phoneNumber = State(initialValue: user.phoneNumber ?? "")
+    }
 
     var body: some View {
         ZStack {
@@ -30,16 +42,40 @@ struct AccountInformationView: View {
                 }
 
                 Section("Phone Number") {
-                    HStack {
-                        Image(systemName: "phone")
-                            .foregroundColor(.secondary)
+                    TextField("Phone Number (optional)", text: $phoneNumber)
+                        .keyboardType(.phonePad)
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
 
-                        Text(user.phoneNumber ?? "Unavailable")
-                            .foregroundColor(.white)
+                    Button {
+                        Task { await saveAccountInfo() }
+                    } label: {
+                        HStack {
+                            if isSaving {
+                                ProgressView()
+                            }
+                            Text(isSaving ? "Saving..." : "Save Phone Number")
+                        }
                     }
-                    Text("Phone number editing is temporarily unavailable.")
-                        .font(.footnote)
-                        .foregroundColor(.secondary)
+                    .disabled(isSaving || !isPhoneNumberValid)
+
+                    if !isPhoneNumberValid {
+                        Text("Enter a valid US phone number or leave blank")
+                            .font(.footnote)
+                            .foregroundColor(.orange)
+                    }
+
+                    if showSaved {
+                        Text("Saved")
+                            .font(.footnote)
+                            .foregroundColor(.green)
+                    }
+
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundColor(.red)
+                    }
                 }
 
                 Section("Security") {
@@ -63,7 +99,34 @@ struct AccountInformationView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func normalizedPhone(_ value: String) -> String {
-        value.filter(\.isNumber)
+    private var isPhoneNumberValid: Bool {
+        let trimmed = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        let digits = trimmed.filter(\.isNumber)
+        return digits.count == 10 || (digits.count == 11 && digits.first == "1")
+    }
+
+    private func saveAccountInfo() async {
+        guard !isSaving else { return }
+        guard isPhoneNumberValid else { return }
+
+        isSaving = true
+        showSaved = false
+        errorMessage = nil
+        defer { isSaving = false }
+
+        do {
+            let trimmed = phoneNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+            let updated = try await APIService.shared.updateAccountInformation(
+                phoneNumber: trimmed.isEmpty ? nil : trimmed
+            )
+
+            authManager.currentUser = updated
+            onUserUpdated?(updated)
+            showSaved = true
+            phoneNumber = updated.phoneNumber ?? ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Add Apple Sign-In to provide an additional OAuth option and reuse the existing backend sync flow with Firebase.
- Make `phone_number` optional in the signup flow so social signups and partial profiles can proceed without a phone number.
- Allow users to view and edit their phone number in the app and normalize/validate phone input on the client.

### Description

- Backend: updated `completeProfile` to treat `phone_number` as optional and only check uniqueness when a non-empty phone number is provided in `completeProfile`.
- Frontend (iOS): added an `AppleSignInHandler` (nonce generation, `sha256`, and credential exchange) and integrated `SignInWithAppleButton` into `CreateAccountView` and `LoginView`, reusing the existing `AuthManager.syncSessionWithBackend()` flow after Firebase sign-in.
- Frontend: relaxed phone handling across UI flows by making phone input optional and introducing `isPhoneNumberValidOrEmpty` helper and similar validation logic in `CreateAccountView`, `UsernameSetupView`, and `AccountInformationView`.
- Frontend: updated `APIService` JSON decoding to set `keyDecodingStrategy = .convertFromSnakeCase` for `UserResponse` decoding to match backend snake_case keys.
- Frontend: implemented phone-editing in `AccountInformationView` with `saveAccountInfo()` that calls `APIService.shared.updateAccountInformation`, updates `authManager.currentUser`, and shows inline success/error state.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d934024790832f964a70220c15c598)